### PR TITLE
feat: adds support to quarkus 2.4.1.Final and temporal-sdk 1.5.0

### DIFF
--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -17,7 +17,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>2.2.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.4.1.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     </properties>
     <dependencies>

--- a/integration-tests/src/test/java/io/quarkus/temporal/client/it/TemporalClientResourceTest.java
+++ b/integration-tests/src/test/java/io/quarkus/temporal/client/it/TemporalClientResourceTest.java
@@ -1,21 +1,20 @@
-//package io.quarkus.temporal.client.it;
-//
-//import static io.restassured.RestAssured.given;
-//import static org.hamcrest.Matchers.is;
-//
-//import org.junit.jupiter.api.Test;
-//
-//import io.quarkus.test.junit.QuarkusTest;
-//
-//@QuarkusTest
-//public class TemporalClientResourceTest {
-//
-//    @Test
-//    public void testHelloEndpoint() {
-//        given()
-//                .when().get("/temporal-client")
-//                .then()
-//                .statusCode(200)
-//                .body(is("Hello temporal-client"));
-//    }
-//}
+package io.quarkus.temporal.client.it;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+
+@QuarkusTest
+@Disabled("to run this test it is necessary to have the temporal stack up")
+public class TemporalClientResourceTest {
+
+    @Test
+    public void testHelloEndpoint() {
+        given()
+                .when().get("/trip")
+                .then()
+                .statusCode(200);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -49,11 +49,11 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <maven.compiler.parameters>true</maven.compiler.parameters>
-        <quarkus.version>2.2.1.Final</quarkus.version>
+        <quarkus.version>2.4.1.Final</quarkus.version>
         <doma.version>2.47.1</doma.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
-        <temporal.version>1.2.0</temporal.version>
+        <temporal.version>1.5.0</temporal.version>
     </properties>
 
     <dependencyManagement>
@@ -64,12 +64,6 @@
                 <version>${quarkus.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
-            </dependency>
-            <!-- just necessary when quarkus < 2.3 -->
-            <dependency>
-                <groupId>io.grpc</groupId>
-                <artifactId>grpc-netty-shaded</artifactId>
-                <version>1.39.0</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>io.temporal</groupId>
             <artifactId>temporal-sdk</artifactId>
-            <version>${temporal.version}</version>
+            <version>1.5.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>io.grpc</groupId>
@@ -41,12 +41,12 @@
         <dependency>
             <groupId>org.graalvm.nativeimage</groupId>
             <artifactId>svm</artifactId>
-            <version>21.2.0</version>
+            <version>21.3.0</version>
         </dependency>
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-netty-shaded</artifactId>
-            <version>1.39.0</version>
+            <version>1.41.0</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
When using the most current version of `Quarkus` the app does not start.


I suggest that when releasing a release of this issue, go up to `major` version is not guaranteed to work in previous versions.